### PR TITLE
Added Dockerfile for Intel OneAPI 2024.2.0

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -46,6 +46,8 @@ jobs:
           - toolchain: clang
             version: 19
           - toolchain: mojo
+          - toolchain: oneapi
+            version: 2024.2.0
 
     env:
       REGISTRY: ghcr.io

--- a/oneapi/2024.2.0/Dockerfile
+++ b/oneapi/2024.2.0/Dockerfile
@@ -31,8 +31,9 @@ RUN apt-get update -y \
  # cleanup
  && rm -rf /tmp/* /var/lib/apt/lists/*
 
-ENV CC=icpc \
-    CXX=icpx
+ENV CC=icx \
+    CXX=icpx \
+    FC=ifx
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/oneapi/2024.2.0/Dockerfile
+++ b/oneapi/2024.2.0/Dockerfile
@@ -12,10 +12,9 @@ RUN apt-get update -y \
  && chmod +x /tmp/install-cmake \
  && /tmp/install-cmake --prefix=/usr --skip-license \
  # Download and install Intel OneAPI standalone compiler
- && wget --no-verbose https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh --no-check-certificate -O intel_dpcpp.sh \
- && sh ./intel_dpcpp.sh -a --action install --components intel.oneapi.lin.dpcpp-cpp-compiler --silent --eula accept \
- && rm -f ./intel_dpcpp.sh \
- # tmp
+ && wget --no-verbose --no-check-certificate -O /tmp/intel_dpcpp.sh https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh \
+ && sh /tmp/intel_dpcpp.sh -a --action install --components intel.oneapi.lin.dpcpp-cpp-compiler --silent --eula accept \
+ # Needed just to allow boost to find OneAPI
  && . /opt/intel/oneapi/setvars.sh \
  # boost
  && mkdir -p /tmp/boost \

--- a/oneapi/2024.2.0/Dockerfile
+++ b/oneapi/2024.2.0/Dockerfile
@@ -1,0 +1,36 @@
+FROM gcc:13
+LABEL org.opencontainers.image.source="https://github.com/nazavode/docker-toolchain"
+
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends \
+    git \
+    wget \
+    numdiff \
+    libblas-dev \
+    liblapack-dev \
+ # cmake
+ && wget -O /tmp/install-cmake -q https://github.com/Kitware/CMake/releases/download/v3.30.2/cmake-3.30.2-linux-x86_64.sh \
+ && chmod +x /tmp/install-cmake \
+ && /tmp/install-cmake --prefix=/usr --skip-license \
+ # boost
+ && mkdir -p /tmp/boost \
+ && wget -q -O - https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz | tar xzf - -C /tmp/boost --strip-components 1 \
+ && cd /tmp/boost \
+ && ./bootstrap.sh --with-toolset=gcc --with-libraries=graph,program_options --prefix=/usr \
+ && ./b2 toolset=gcc --with-graph --with-program_options stage \
+ && ./b2 toolset=gcc --with-graph --with-program_options install \
+ # Download and install Intel OneAPI standalone compiler
+ && wget --no-verbose https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh --no-check-certificate -O intel_dpcpp.sh \
+ && sh ./intel_dpcpp.sh -a --action install --components intel.oneapi.lin.dpcpp-cpp-compiler --silent --eula accept \
+ && rm -f ./intel_dpcpp.sh \
+ # Remove unneeded stuff
+ && apt-get remove wget -y \
+ && apt-get clean autoclean \
+ && apt-get autoremove -y \
+ # cleanup
+ && rm -rf /tmp/* /var/lib/apt/lists/* \
+ # Setup environment variables automatically on startup
+ && echo ". /opt/intel/oneapi/setvars.sh" >> ~/.bashrc
+
+ENV CC=icpc \
+    CXX=icpx

--- a/oneapi/2024.2.0/Dockerfile
+++ b/oneapi/2024.2.0/Dockerfile
@@ -31,8 +31,7 @@ RUN apt-get update -y \
  && rm -rf /tmp/* /var/lib/apt/lists/*
 
 ENV CC=icx \
-    CXX=icpx \
-    FC=ifx
+    CXX=icpx
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/oneapi/2024.2.0/Dockerfile
+++ b/oneapi/2024.2.0/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update -y \
     wget \
     numdiff \
     libblas-dev \
-    liblapack-dev \
  # cmake
  && wget -O /tmp/install-cmake -q https://github.com/Kitware/CMake/releases/download/v3.30.2/cmake-3.30.2-linux-x86_64.sh \
  && chmod +x /tmp/install-cmake \

--- a/oneapi/2024.2.0/Dockerfile
+++ b/oneapi/2024.2.0/Dockerfile
@@ -11,17 +11,19 @@ RUN apt-get update -y \
  && wget -O /tmp/install-cmake -q https://github.com/Kitware/CMake/releases/download/v3.30.2/cmake-3.30.2-linux-x86_64.sh \
  && chmod +x /tmp/install-cmake \
  && /tmp/install-cmake --prefix=/usr --skip-license \
- # boost
- && mkdir -p /tmp/boost \
- && wget -q -O - https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz | tar xzf - -C /tmp/boost --strip-components 1 \
- && cd /tmp/boost \
- && ./bootstrap.sh --with-toolset=gcc --with-libraries=graph,program_options --prefix=/usr \
- && ./b2 toolset=gcc --with-graph --with-program_options stage \
- && ./b2 toolset=gcc --with-graph --with-program_options install \
  # Download and install Intel OneAPI standalone compiler
  && wget --no-verbose https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_2024.2.0.495_offline.sh --no-check-certificate -O intel_dpcpp.sh \
  && sh ./intel_dpcpp.sh -a --action install --components intel.oneapi.lin.dpcpp-cpp-compiler --silent --eula accept \
  && rm -f ./intel_dpcpp.sh \
+ # tmp
+ && . /opt/intel/oneapi/setvars.sh \
+ # boost
+ && mkdir -p /tmp/boost \
+ && wget -q -O - https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz | tar xzf - -C /tmp/boost --strip-components 1 \
+ && cd /tmp/boost \
+ && ./bootstrap.sh --with-toolset=intel-linux --with-libraries=graph,program_options --prefix=/usr \
+ && ./b2 toolset=intel-linux --with-graph --with-program_options stage \
+ && ./b2 toolset=intel-linux --with-graph --with-program_options install \
  # Remove unneeded stuff
  && apt-get remove wget -y \
  && apt-get clean autoclean \

--- a/oneapi/2024.2.0/Dockerfile
+++ b/oneapi/2024.2.0/Dockerfile
@@ -28,9 +28,10 @@ RUN apt-get update -y \
  && apt-get clean autoclean \
  && apt-get autoremove -y \
  # cleanup
- && rm -rf /tmp/* /var/lib/apt/lists/* \
- # Setup environment variables automatically on startup
- && echo ". /opt/intel/oneapi/setvars.sh" >> ~/.bashrc
+ && rm -rf /tmp/* /var/lib/apt/lists/*
 
 ENV CC=icpc \
     CXX=icpx
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/oneapi/2024.2.0/entrypoint.sh
+++ b/oneapi/2024.2.0/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+. /opt/intel/oneapi/setvars.sh
+
+exec "$@"


### PR DESCRIPTION
At the moment, the new container is based on gcc-13 because OneAPI needs to use it as backend compiler and also for the linker. Also, boost 1.86 is compiled with gcc13.
Let me know if you want this to change.