### PR TITLE
Moved CC and CXX in entrypoint

### DIFF
--- a/oneapi/2024.2.0/Dockerfile
+++ b/oneapi/2024.2.0/Dockerfile
@@ -31,8 +31,5 @@ RUN apt-get update -y \
  # cleanup
  && rm -rf /tmp/* /var/lib/apt/lists/*
 
-ENV CC=icx \
-    CXX=icpx
-
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/oneapi/2024.2.0/entrypoint.sh
+++ b/oneapi/2024.2.0/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 . /opt/intel/oneapi/setvars.sh
+export CC=icx
+export CXX=icpx
 
 exec "$@"


### PR DESCRIPTION
Apparently, setting `CC=icx` and `CXX=icpx` before `setvars.sh` messes up with CMake configuration.
So, I moved it into the entrypoint script.