### PR TITLE
Added cmake to PATH

### DIFF
--- a/oneapi/2024.2.0-rhel-ubi9/entrypoint.sh
+++ b/oneapi/2024.2.0-rhel-ubi9/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+. /opt/rh/gcc-toolset-14/enable
 . /opt/intel/oneapi/setvars.sh
 export CC=icx
 export CXX=icpx


### PR DESCRIPTION
The container oneapi2024.2.0-rhel-ubi9 did not enable the gcc toolset resulting in cmake not being found in PATH.